### PR TITLE
Stop using linker optimization

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -15,11 +15,12 @@ vcpkg_from_github(
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DPYTHON_EXECUTABLE=${PYTHON3}
-        -DLIB_SUFFIX=
         -DBUILD_GO=no
-        -DENABLE_JSONCPP=ON
         -DCMAKE_DISABLE_FIND_PACKAGE_CyrusSASL=ON
+        -DENABLE_JSONCPP=ON
+        -DENABLE_LINKTIME_OPTIMIZATION=OFF
+        -DLIB_SUFFIX=
+        -DPYTHON_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_cmake_install()

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.32.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "dependencies": [

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5646,7 +5646,7 @@
     },
     "qpid-proton": {
       "baseline": "0.32.0",
-      "port-version": 4
+      "port-version": 5
     },
     "qscintilla": {
       "baseline": "2.12.0",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "1b9b8fa3e5b7b6759cb19a7ed211c3720738dc30",
+      "version": "0.32.0",
+      "port-version": 5
+    },
+    {
       "git-tree": "be327f08d64834a36d80a140832abbbc66e67207",
       "version": "0.32.0",
       "port-version": 4


### PR DESCRIPTION
These optimizations require the gold linker on Linux, and this linker is not typically available.
