### PR TITLE
Fix errors [1,2] (PYTHON_EXECUTABLE, references file not existing)

### DIFF
--- a/ports/qpid-proton/portfile.cmake
+++ b/ports/qpid-proton/portfile.cmake
@@ -22,16 +22,23 @@ vcpkg_cmake_configure(
         -DENABLE_BENCHMARKS=OFF
         -DENABLE_FUZZ_TESTING=OFF
         -DBUILD_TESTING=OFF
-        -DPYTHON_EXECUTABLE=${PYTHON3}
+        -DPython_EXECUTABLE=${PYTHON3}
 )
 
 vcpkg_cmake_install()
 
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+file(GLOB protonCmakeFiles LIST_DIRECTORIES false "${CURRENT_PACKAGES_DIR}/share/${PORT}/Proton/*.cmake")
+file(GLOB protonCppCmakeFiles LIST_DIRECTORIES false "${CURRENT_PACKAGES_DIR}/share/${PORT}/ProtonCpp/*.cmake")
+set(cmakeFiles ${protonCmakeFiles} ${protonCppCmakeFiles})
+foreach(cmakeFile IN LISTS cmakeFiles)
+    get_filename_component(filename "${cmakeFile}" NAME)
+    file(RENAME "${cmakeFile}" "${CURRENT_PACKAGES_DIR}/share/${PORT}/${filename}")
+endforeach()
 set(configFiles
-    "${CURRENT_PACKAGES_DIR}/share/${PORT}/Proton/ProtonConfig.cmake"
-    "${CURRENT_PACKAGES_DIR}/share/${PORT}/ProtonCpp/ProtonCppConfig.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/ProtonConfig.cmake"
+    "${CURRENT_PACKAGES_DIR}/share/${PORT}/ProtonCppConfig.cmake"
 )
 foreach(configFile IN LISTS configFiles)
     vcpkg_replace_string("${configFile}"

--- a/ports/qpid-proton/qpid-protonConfig.cmake
+++ b/ports/qpid-proton/qpid-protonConfig.cmake
@@ -1,4 +1,4 @@
 get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
 set(_IMPORT_PREFIX "${PACKAGE_PREFIX_DIR}")
-include(${CMAKE_CURRENT_LIST_DIR}/Proton/ProtonConfig.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/ProtonCpp/ProtonCppConfig.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ProtonConfig.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/ProtonCppConfig.cmake)

--- a/ports/qpid-proton/vcpkg.json
+++ b/ports/qpid-proton/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "qpid-proton",
   "version": "0.37.0",
+  "port-version": 1,
   "description": "Qpid Proton is a high-performance, lightweight messaging library.",
   "homepage": "https://github.com/apache/qpid-proton",
   "license": "Apache-2.0",

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5650,7 +5650,7 @@
     },
     "qpid-proton": {
       "baseline": "0.37.0",
-      "port-version": 0
+      "port-version": 1
     },
     "qscintilla": {
       "baseline": "2.12.0",

--- a/versions/q-/qpid-proton.json
+++ b/versions/q-/qpid-proton.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "2af8cc402d1778c44f8b24bdd6d8b1de364ccaf3",
+      "version": "0.37.0",
+      "port-version": 1
+    },
+    {
       "git-tree": "720cc65a7b408878662ce7c749211fa7edaf25fd",
       "version": "0.37.0",
       "port-version": 0


### PR DESCRIPTION
[1] Both PYTHON_EXECUTABLE and Python_EXECUTABLE are defined. Define at most one of those.
[2] The imported target "Proton::qpid-proton" references the file

     "C:/BuildTools/cmf/debug/vcpkg_installed/x64-windows/share/debug/lib/qpid-protond.lib"

  but this file does not exist.