### PR TITLE
Add RUNPATH (RPATH) to cpprestsdk

### DIFF
--- a/ports/cpprestsdk/portfile.cmake
+++ b/ports/cpprestsdk/portfile.cmake
@@ -27,6 +27,11 @@ if(VCPKG_TARGET_IS_UWP)
     set(configure_opts WINDOWS_USE_MSBUILD)
 endif()
 
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    set(rpath "@loader_path")
+else()
+    set(rpath "\$ORIGIN")
+endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}/Release"
     ${configure_opts}
@@ -35,6 +40,7 @@ vcpkg_cmake_configure(
         ${FEATURE_OPTIONS}
         -DBUILD_TESTS=OFF
         -DBUILD_SAMPLES=OFF
+        -DCMAKE_INSTALL_RPATH=${rpath}
         -DCPPREST_EXPORT_DIR=share/cpprestsdk
         -DWERROR=OFF
         -DPKG_CONFIG_EXECUTABLE=FALSE

--- a/ports/cpprestsdk/vcpkg.json
+++ b/ports/cpprestsdk/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "cpprestsdk",
   "version": "2.10.18",
-  "port-version": 1,
+  "port-version": 2,
   "description": [
     "C++11 JSON, REST, and OAuth library",
     "The C++ REST SDK is a Microsoft project for cloud-based client-server communication in native code using a modern asynchronous C++ API design. This project aims to help C++ developers connect to and interact with services."

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -1654,7 +1654,7 @@
     },
     "cpprestsdk": {
       "baseline": "2.10.18",
-      "port-version": 1
+      "port-version": 2
     },
     "cpptoml": {
       "baseline": "v0.1.1",

--- a/versions/c-/cpprestsdk.json
+++ b/versions/c-/cpprestsdk.json
@@ -1,6 +1,11 @@
 {
   "versions": [
     {
+      "git-tree": "75bdd4f1f618d6dd8714e5893376cf56229129c4",
+      "version": "2.10.18",
+      "port-version": 2
+    },
+    {
       "git-tree": "b37c56224faff461184f427b95f10dc320d74d50",
       "version": "2.10.18",
       "port-version": 1


### PR DESCRIPTION
I'll open the issue in vcpkg once this is approved. I tested with `VCPKG_OVERLAY_PORTS` and this solve the issue I had (cpprestsdk was not finding libboost-random on Linux)